### PR TITLE
fix the paddle query selector

### DIFF
--- a/src/client/MyRenderer.js
+++ b/src/client/MyRenderer.js
@@ -21,7 +21,7 @@ class MyRenderer extends Renderer {
     }
 
     addSprite(obj, objName) {
-        if (objName === 'paddle') objName += obj.playerId;
+        if (objName === 'paddle') objName += obj.id;
         this.sprites[obj.id] = {
             el: document.querySelector('.' + objName)
         };


### PR DESCRIPTION
First of all I would like to say you guys did a great job here, Lance is without doubt a wonderful library for those who want to develop multiplayer games. Going back to the issue...

The query selector was built using the player id (`obj.playerId`) when it should use the object id (`obj.id`). This issue lead to unresponsive paddle due to some invalid player id being used.