### PR TITLE
causing an error on yarn start b/c of bad version given

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "browserify": "^13.0.1",
     "express": "^4.14.0",
-    "lance-gg": "~1.0.0",
+    "lance-gg": "1.0.1",
     "query-string": "^4.2.3",
     "socket.io": "^1.4.8"
   },


### PR DESCRIPTION
fixes this error: this.physicsEngine = new PhysicsEngine();
TypeError: PhysicsEngine is not a constructor
appeared while doing pong tutorial. Would work from pull pong branch code.